### PR TITLE
F2F-76t4: Adjusted HelloWorld to skip CKV_AWS_116

### DIFF
--- a/lambda-functions/template.yaml
+++ b/lambda-functions/template.yaml
@@ -160,6 +160,7 @@ Resources:
         Service: backend
         Name: HelloWorldFunction
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
+        CheckovRulesToSkip: "CKV_AWS_116"
 
   CodeDeployServiceRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Added tag to HelloWorld to skip CKV_AWS_116 (DLQ), also added this to be skipped in the checkov hook in aws console. 